### PR TITLE
Use nanosleep instead of usleep.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,22 @@ start with, therefore getting familiar with the project.
 
 ## Features
 
-1. Single File and Small Codebase;
-2. Fully Standalone(No 3rd library needed, only rely on toxcore and system c lib);
-3. Covered most apis of Friend&Group, and more to go;
-4. Fun to play with(Colored text, Async REPL, etc.).
+1. Single file and small codebase;
+2. Fully standalone (No 3rd library needed, only rely on toxcore and system C library);
+3. Covered most APIs of friend & group, and more to come;
+4. Fun to play with (colored text, async REPL, etc.).
 
 ## Build
 
-If [toxcore](https://github.com/TokTok/c-toxcore) has been installed into system path, Use
+If [toxcore](https://github.com/TokTok/c-toxcore) has been installed into the
+system path, use
 
 ```sh
 make
 ```
 
-Or link it manually (assume libtoxcore.so in TOX\_LIB\_DIR, tox.h in TOX\_H\_DIR/tox):
+Or link it manually (assuming `libtoxcore.so` exists in `TOX_LIB_DIR`, and
+`tox.h` in `TOX_H_DIR/tox`):
 
 ```sh
 $ gcc -o minitox minitox.c -I TOX_H_DIR -L TOX_LIB_DIR -Wl,-rpath TOX_LIB_DIR -ltoxcore
@@ -30,6 +32,6 @@ $ gcc -o minitox minitox.c -I TOX_H_DIR -L TOX_LIB_DIR -Wl,-rpath TOX_LIB_DIR -l
 
 ## Config
 
-To keep simple, `minitox` does not provid command line options,except for `-h` and `--help`.
-To change its behaviour, you are encouraged to modify the source file and rebuild. The source
-file has been heavily commented.
+To keep things simple, `minitox` does not provide command line options, except
+for `-h` and `--help`. To change its behaviour, you are encouraged to modify
+the source file and rebuild. The source file has been heavily commented.

--- a/minitox.c
+++ b/minitox.c
@@ -2,6 +2,10 @@
  * MiniTox - A minimal client for Tox
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -1342,7 +1346,11 @@ int main(int argc, char **argv) {
         tox_iterate(tox, NULL);
         uint32_t v = tox_iteration_interval(tox);
         msecs += v;
-        usleep(v * 1000);
+
+        struct timespec pause;
+        pause.tv_sec = 0;
+        pause.tv_nsec = v * 1000 * 1000;
+        nanosleep(&pause, NULL);
     }
 
     return 0;


### PR DESCRIPTION
The latter is obsolete since 2001 and removed since 2008.